### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/dynamic_widget/scrolling/gridview_widget_parser.dart
+++ b/lib/dynamic_widget/scrolling/gridview_widget_parser.dart
@@ -202,7 +202,7 @@ class _GridViewWidgetState extends State<GridViewWidget> {
           _params.loadMoreUrl, _items.length, _params.pageSize)));
       var response = await request.close();
       if (response.statusCode == HttpStatus.ok) {
-        var json = await response.transform(utf8.decoder).join();
+        var json = await utf8.decoder.bind(response).join();
         return json;
       }
     } catch (exception) {

--- a/lib/dynamic_widget/scrolling/listview_widget_parser.dart
+++ b/lib/dynamic_widget/scrolling/listview_widget_parser.dart
@@ -182,7 +182,7 @@ class _ListViewWidgetState extends State<ListViewWidget> {
           _params.loadMoreUrl, _items.length, _params.pageSize)));
       var response = await request.close();
       if (response.statusCode == HttpStatus.ok) {
-        var json = await response.transform(utf8.decoder).join();
+        var json = await utf8.decoder.bind(response).join();
         return json;
       }
     } catch (exception) {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
