### PR TITLE
Fix json number parse

### DIFF
--- a/lib/dynamic_widget/basic/sizedbox_widget_parser.dart
+++ b/lib/dynamic_widget/basic/sizedbox_widget_parser.dart
@@ -21,8 +21,8 @@ class SizedBoxWidgetParser extends WidgetParser {
   Widget parse(Map<String, dynamic> map, BuildContext buildContext,
       ClickListener listener) {
     return SizedBox(
-      width: map["width"],
-      height: map["height"],
+      width: (map["width"] as num)?.toDouble(),
+      height: (map["height"] as num)?.toDouble(),
       child: DynamicWidgetBuilder.buildFromMap(
           map["child"], buildContext, listener),
     );

--- a/lib/dynamic_widget/utils.dart
+++ b/lib/dynamic_widget/utils.dart
@@ -140,7 +140,7 @@ TextStyle parseTextStyle(Map<String, dynamic> map) {
   String debugLabel = map['debugLabel'];
   String decoration = map['decoration'];
   String fontFamily = map['fontFamily'];
-  double fontSize = map['fontSize'];
+  double fontSize = (map['fontSize'] as num)?.toDouble();
   String fontWeight = map['fontWeight'];
   FontStyle fontStyle =
       'italic' == map['fontStyle'] ? FontStyle.italic : FontStyle.normal;


### PR DESCRIPTION
Fix SizedBox and FontSize int to double parser.

When a JSON is minified. Any *double without decimal* is converted to *int* e.g: `20.0` -> `20

This PR safely cast and parse to double if the value exists.
