### PR TITLE
add support for parsing theme color

### DIFF
--- a/lib/dynamic_widget/basic/appbar_widget_parser.dart
+++ b/lib/dynamic_widget/basic/appbar_widget_parser.dart
@@ -45,7 +45,7 @@ class AppBarWidgetParser extends WidgetParser {
       centerTitle:
           map.containsKey("centerTitle") ? map["centerTitle"] as bool : false,
       backgroundColor: map.containsKey("backgroundColor")
-          ? parseHexColor(map["backgroundColor"])
+          ? parseColor(buildContext, map["backgroundColor"])
           : null,
     );
 

--- a/lib/dynamic_widget/basic/button_widget_parser.dart
+++ b/lib/dynamic_widget/basic/button_widget_parser.dart
@@ -10,15 +10,17 @@ class RaisedButtonParser extends WidgetParser {
         map.containsKey("click_event") ? map['click_event'] : "";
 
     var raisedButton = RaisedButton(
-      color: map.containsKey('color') ? parseHexColor(map['color']) : null,
+      color: map.containsKey('color')
+          ? parseColor(buildContext, map['color'])
+          : null,
       disabledColor: map.containsKey('disabledColor')
-          ? parseHexColor(map['disabledColor'])
+          ? parseColor(buildContext, map['disabledColor'])
           : null,
       disabledElevation: map.containsKey('disabledElevation')
           ? map['disabledElevation']?.toDouble()
           : 0.0,
       disabledTextColor: map.containsKey('disabledTextColor')
-          ? parseHexColor(map['disabledTextColor'])
+          ? parseColor(buildContext, map['disabledTextColor'])
           : null,
       elevation:
           map.containsKey('elevation') ? map['elevation']?.toDouble() : 0.0,
@@ -26,10 +28,11 @@ class RaisedButtonParser extends WidgetParser {
           ? parseEdgeInsetsGeometry(map['padding'])
           : null,
       splashColor: map.containsKey('splashColor')
-          ? parseHexColor(map['splashColor'])
+          ? parseColor(buildContext, map['splashColor'])
           : null,
-      textColor:
-          map.containsKey('textColor') ? parseHexColor(map['textColor']) : null,
+      textColor: map.containsKey('textColor')
+          ? parseColor(buildContext, map['textColor'])
+          : null,
       child: DynamicWidgetBuilder.buildFromMap(
           map['child'], buildContext, listener),
       onPressed: () {

--- a/lib/dynamic_widget/basic/container_widget_parser.dart
+++ b/lib/dynamic_widget/basic/container_widget_parser.dart
@@ -7,7 +7,7 @@ class ContainerWidgetParser extends WidgetParser {
   Widget parse(Map<String, dynamic> map, BuildContext buildContext,
       ClickListener listener) {
     Alignment alignment = parseAlignment(map['alignment']);
-    Color color = parseHexColor(map['color']);
+    Color color = parseColor(buildContext, map['color']);
     BoxConstraints constraints = parseBoxConstraints(map['constraints']);
     //TODO: decoration, foregroundDecoration and transform properties to be implemented.
     EdgeInsetsGeometry margin = parseEdgeInsetsGeometry(map['margin']);

--- a/lib/dynamic_widget/basic/dropcaptext_widget_parser.dart
+++ b/lib/dynamic_widget/basic/dropcaptext_widget_parser.dart
@@ -13,9 +13,9 @@ class DropCapTextParser extends WidgetParser {
       mode: map.containsKey('mode')
           ? parseDropCapMode(map['mode'])
           : DropCapMode.inside,
-      style: map.containsKey('style') ? parseTextStyle(map['style']) : null,
+      style: map.containsKey('style') ? parseTextStyle(buildContext, map['style']) : null,
       dropCapStyle: map.containsKey('dropCapStyle')
-          ? parseTextStyle(map['dropCapStyle'])
+          ? parseTextStyle(buildContext, map['dropCapStyle'])
           : null,
       textAlign: map.containsKey('textAlign')
           ? parseTextAlign(map['textAlign'])

--- a/lib/dynamic_widget/basic/icon_widget_parser.dart
+++ b/lib/dynamic_widget/basic/icon_widget_parser.dart
@@ -12,7 +12,9 @@ class IconWidgetParser extends WidgetParser {
           ? getIconUsingPrefix(name: map['data'])
           : Icons.android,
       size: map.containsKey("size") ? map['size']?.toDouble() : null,
-      color: map.containsKey('color') ? parseHexColor(map['color']) : null,
+      color: map.containsKey('color')
+          ? parseColor(buildContext, map['color'])
+          : null,
       semanticLabel:
           map.containsKey('semanticLabel') ? map['semanticLabel'] : null,
       textDirection: map.containsKey('textDirection')

--- a/lib/dynamic_widget/basic/image_widget_parser.dart
+++ b/lib/dynamic_widget/basic/image_widget_parser.dart
@@ -18,7 +18,9 @@ class AssetImageWidgetParser extends WidgetParser {
     double width = map.containsKey('width') ? map['width']?.toDouble() : null;
     double height =
         map.containsKey('height') ? map['height']?.toDouble() : null;
-    Color color = map.containsKey('color') ? parseHexColor(map['color']) : null;
+    Color color = map.containsKey('color')
+        ? parseColor(buildContext, map['color'])
+        : null;
     BlendMode blendMode =
         map.containsKey('blendMode') ? parseBlendMode(map['blendMode']) : null;
     BoxFit boxFit =
@@ -207,7 +209,9 @@ class NetworkImageWidgetParser extends WidgetParser {
     double width = map.containsKey('width') ? map['width']?.toDouble() : null;
     double height =
         map.containsKey('height') ? map['height']?.toDouble() : null;
-    Color color = map.containsKey('color') ? parseHexColor(map['color']) : null;
+    Color color = map.containsKey('color')
+        ? parseColor(buildContext, map['color'])
+        : null;
     BlendMode blendMode =
         map.containsKey('blendMode') ? parseBlendMode(map['blendMode']) : null;
     BoxFit boxFit =

--- a/lib/dynamic_widget/basic/placeholder_widget_parser.dart
+++ b/lib/dynamic_widget/basic/placeholder_widget_parser.dart
@@ -8,7 +8,7 @@ class PlaceholderWidgetParser extends WidgetParser {
       ClickListener listener) {
     return Placeholder(
       color: map.containsKey('color')
-          ? parseHexColor(map['color'])
+          ? parseColor(buildContext, map['color'])
           : const Color(0xFF455A64),
       strokeWidth:
           map.containsKey('strokeWidth') ? map['strokeWidth']?.toDouble() : 2.0,

--- a/lib/dynamic_widget/basic/scaffold_widget_parser.dart
+++ b/lib/dynamic_widget/basic/scaffold_widget_parser.dart
@@ -37,7 +37,7 @@ class ScaffoldWidgetParser extends WidgetParser {
               map["floatingActionButton"], buildContext, listener)
           : null,
       backgroundColor: map.containsKey("backgroundColor")
-          ? parseHexColor(map["backgroundColor"])
+          ? parseColor(buildContext, map["backgroundColor"])
           : null,
     );
 

--- a/lib/dynamic_widget/basic/selectabletext_widget_parser.dart
+++ b/lib/dynamic_widget/basic/selectabletext_widget_parser.dart
@@ -15,7 +15,7 @@ class SelectableTextWidgetParser implements WidgetParser {
     var textSpan;
     var textSpanParser = SelectableTextSpanParser();
     if (map.containsKey("textSpan")) {
-      textSpan = textSpanParser.parse(map['textSpan'], listener);
+      textSpan = textSpanParser.parse(buildContext, map['textSpan'], listener);
     }
 
     if (textSpan == null) {
@@ -24,7 +24,9 @@ class SelectableTextWidgetParser implements WidgetParser {
         textAlign: parseTextAlign(textAlignString),
         maxLines: maxLines,
         textDirection: parseTextDirection(textDirectionString),
-        style: map.containsKey('style') ? parseTextStyle(map['style']) : null,
+        style: map.containsKey('style')
+            ? parseTextStyle(buildContext, map['style'])
+            : null,
 //        textScaleFactor: textScaleFactor,
       );
     } else {
@@ -33,7 +35,9 @@ class SelectableTextWidgetParser implements WidgetParser {
         textAlign: parseTextAlign(textAlignString),
         maxLines: maxLines,
         textDirection: parseTextDirection(textDirectionString),
-        style: map.containsKey('style') ? parseTextStyle(map['style']) : null,
+        style: map.containsKey('style')
+            ? parseTextStyle(buildContext, map['style'])
+            : null,
 //        textScaleFactor: textScaleFactor,
       );
     }
@@ -79,11 +83,12 @@ class SelectableTextWidgetParser implements WidgetParser {
 }
 
 class SelectableTextSpanParser {
-  TextSpan parse(Map<String, dynamic> map, ClickListener listener) {
+  TextSpan parse(BuildContext buildContext, Map<String, dynamic> map,
+      ClickListener listener) {
     String clickEvent = map.containsKey("recognizer") ? map['recognizer'] : "";
     var textSpan = TextSpan(
         text: map['text'],
-        style: parseTextStyle(map['style']),
+        style: parseTextStyle(buildContext, map['style']),
         recognizer: TapGestureRecognizer()
           ..onTap = () {
             listener.onClicked(clickEvent);
@@ -91,16 +96,16 @@ class SelectableTextSpanParser {
         children: []);
 
     if (map.containsKey('children')) {
-      parseChildren(textSpan, map['children'], listener);
+      parseChildren(buildContext, textSpan, map['children'], listener);
     }
 
     return textSpan;
   }
 
-  void parseChildren(
-      TextSpan textSpan, List<dynamic> childrenSpan, ClickListener listener) {
+  void parseChildren(BuildContext buildContext, TextSpan textSpan,
+      List<dynamic> childrenSpan, ClickListener listener) {
     for (var childmap in childrenSpan) {
-      textSpan.children.add(parse(childmap, listener));
+      textSpan.children.add(parse(buildContext, childmap, listener));
     }
   }
 

--- a/lib/dynamic_widget/basic/text_widget_parser.dart
+++ b/lib/dynamic_widget/basic/text_widget_parser.dart
@@ -18,7 +18,7 @@ class TextWidgetParser implements WidgetParser {
     var textSpan;
     var textSpanParser = TextSpanParser();
     if (map.containsKey("textSpan")) {
-      textSpan = textSpanParser.parse(map['textSpan'], listener);
+      textSpan = textSpanParser.parse(buildContext, map['textSpan'], listener);
     }
 
     if (textSpan == null) {
@@ -30,7 +30,9 @@ class TextWidgetParser implements WidgetParser {
         semanticsLabel: semanticsLabel,
         softWrap: softWrap,
         textDirection: parseTextDirection(textDirectionString),
-        style: map.containsKey('style') ? parseTextStyle(map['style']) : null,
+        style: map.containsKey('style')
+            ? parseTextStyle(buildContext, map['style'])
+            : null,
         textScaleFactor: textScaleFactor,
       );
     } else {
@@ -42,7 +44,9 @@ class TextWidgetParser implements WidgetParser {
         semanticsLabel: semanticsLabel,
         softWrap: softWrap,
         textDirection: parseTextDirection(textDirectionString),
-        style: map.containsKey('style') ? parseTextStyle(map['style']) : null,
+        style: map.containsKey('style')
+            ? parseTextStyle(buildContext, map['style'])
+            : null,
         textScaleFactor: textScaleFactor,
       );
     }
@@ -100,11 +104,12 @@ class TextWidgetParser implements WidgetParser {
 }
 
 class TextSpanParser {
-  TextSpan parse(Map<String, dynamic> map, ClickListener listener) {
+  TextSpan parse(BuildContext buildContext, Map<String, dynamic> map,
+      ClickListener listener) {
     String clickEvent = map.containsKey("recognizer") ? map['recognizer'] : "";
     var textSpan = TextSpan(
         text: map['text'],
-        style: parseTextStyle(map['style']),
+        style: parseTextStyle(buildContext, map['style']),
         recognizer: TapGestureRecognizer()
           ..onTap = () {
             listener.onClicked(clickEvent);
@@ -112,7 +117,7 @@ class TextSpanParser {
         children: []);
 
     if (map.containsKey('children')) {
-      parseChildren(textSpan, map['children'], listener);
+      parseChildren(buildContext, textSpan, map['children'], listener);
     }
 
     return textSpan;
@@ -126,10 +131,10 @@ class TextSpanParser {
     };
   }
 
-  void parseChildren(
-      TextSpan textSpan, List<dynamic> childrenSpan, ClickListener listener) {
+  void parseChildren(BuildContext buildContext, TextSpan textSpan,
+      List<dynamic> childrenSpan, ClickListener listener) {
     for (var childmap in childrenSpan) {
-      textSpan.children.add(parse(childmap, listener));
+      textSpan.children.add(parse(buildContext, childmap, listener));
     }
   }
 

--- a/lib/dynamic_widget/utils.dart
+++ b/lib/dynamic_widget/utils.dart
@@ -268,7 +268,7 @@ Color parseHexColor(String hexColorString) {
   return Color(colorInt);
 }
 
-TextStyle parseTextStyle(Map<String, dynamic> map) {
+TextStyle parseTextStyle(BuildContext context, Map<String, dynamic> map) {
   if (map == null) {
     return null;
   }
@@ -283,7 +283,7 @@ TextStyle parseTextStyle(Map<String, dynamic> map) {
       'italic' == map['fontStyle'] ? FontStyle.italic : FontStyle.normal;
 
   return TextStyle(
-    color: parseHexColor(color),
+    color: parseColor(context, color),
     debugLabel: debugLabel,
     decoration: parseTextDecoration(decoration),
     fontSize: fontSize,

--- a/lib/dynamic_widget/utils.dart
+++ b/lib/dynamic_widget/utils.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:dynamic_widget/dynamic_widget.dart';
 import 'package:dynamic_widget/dynamic_widget/drop_cap_text.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 TextAlign parseTextAlign(String textAlignString) {
@@ -212,6 +213,47 @@ String exportFontWeight(FontWeight fontWeight) {
     rt = "w900";
   }
   return rt;
+}
+
+Color parseColor(BuildContext context, String color) {
+  if (color == null) {
+    return null;
+  }
+
+  return color.startsWith('::')
+      ? parseThemeColor(Theme.of(context).colorScheme, color)
+      : parseHexColor(color);
+}
+
+Color parseThemeColor(ColorScheme colorScheme, String color) {
+  switch (color) {
+    case '::primary':
+      return colorScheme.primary;
+    case '::primaryVariant':
+      return colorScheme.primaryVariant;
+    case '::onPrimary':
+      return colorScheme.onPrimary;
+    case '::secondary':
+      return colorScheme.secondary;
+    case '::secondaryVariant':
+      return colorScheme.secondaryVariant;
+    case '::onSecondary':
+      return colorScheme.onSecondary;
+    case '::surface':
+      return colorScheme.surface;
+    case '::onSurface':
+      return colorScheme.onSurface;
+    case '::background':
+      return colorScheme.background;
+    case '::onBackground':
+      return colorScheme.onBackground;
+    case '::error':
+      return colorScheme.error;
+    case '::onError':
+      return colorScheme.onError;
+    default:
+      return null;
+  }
 }
 
 Color parseHexColor(String hexColorString) {


### PR DESCRIPTION
Hi there, thanks you making this great package.

In my use case, it's rather difficult to make the color of texts suitable for both light and dark theme. For example, texts of deep grey look good on light theme, but hardly readable on dark theme.
Maybe we could support apply colors defined in colorScheme, e.g. primary, onPrimary, surface, onSurface, etc, to keep the same level of readability regradless of which theme is applied.

In this PR, there is a mapping for themed color, like:
+ ::primary -> colorScheme.primary
+ ::onPrimary -> colorScheme.onPrimary
+ ::surface -> colorScheme.surface
+ ::onSurface -> colorScheme.onSurface
...

There's also limitation: The exported json has to be manually modified, as the code has not idea about the developer's intention (a constant hex color, or a color picked from colorScheme)