### PR TITLE
Remove trip advisor icon

### DIFF
--- a/lib/dynamic_widget/icons_helper.dart
+++ b/lib/dynamic_widget/icons_helper.dart
@@ -2441,7 +2441,6 @@ const Map<String, IconData> FontAwesomeIconsMap = <String, IconData>{
   'trashRestoreAlt': FontAwesomeIcons.trashRestoreAlt,
   'tree': FontAwesomeIcons.tree,
   'trello': FontAwesomeIcons.trello,
-  'tripadvisor': FontAwesomeIcons.tripadvisor,
   'trophy': FontAwesomeIcons.trophy,
   'truck': FontAwesomeIcons.truck,
   'truckLoading': FontAwesomeIcons.truckLoading,


### PR DESCRIPTION
Fixes an issue when using font_awesome_flutter 9.2.0 which removed tripadvisor icon as done in fontawesome.

https://fontawesome.com/v5/changelog/latest